### PR TITLE
Version upgrades: Terraform -> v1.0.0, AWS TF Provider -> v3.37.0, AWS TF EKS module -> v15.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ Bottlerocket can be updated automatically via Kubernetes  Operator
 ## Prerequisites:
 Ensure that you have installed the following tools in your Mac or Windows Laptop before start working with this module and run Terraform Plan and Apply
 
-    1. [aws cli] (https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-    2. [aws-iam-authenticator] (https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
-    3. [kubectl] (https://Kubernetes .io/docs/tasks/tools/)
-    4. wget 
+1. [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+2. [aws-iam-authenticator](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
+3. [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+4. [kubectl](https://kubernetes.io/docs/tasks/tools/)
+5. wget 
     
 ## Deployment Steps
 The following steps walks you through the deployment of example [DEV cluster](live/preprod/eu-west-1/application/dev/base.tfvars) configuration. This config deploys a private EKS cluster with public and private subnets. 
@@ -133,14 +134,15 @@ It also deploys few kubernetes apps i.e., LB Ingress Controller, Metrics Server,
 #### Step1: Clone the repo using the command below
 
     $ git clone https://github.com/aws-samples/aws-eks-accelerator-for-terraform.git
+    $ cd aws-eks-accelerator-for-terraform/source
 
 #### Step2: Update base.tfvars file
 
-Update `~/aws-terraform-eks/live/preprod/eu-west-1/application/dev/base.tfvars` file with the instructions specified in the file (OR use the default values). You can choose to use an existing VPC ID and Subnet IDs or create a new VPC and subnets by providing CIDR ranges in `base.tfvars` file
+Update `~/aws-eks-accelerator-for-terraform/live/preprod/eu-west-1/application/dev/base.tfvars` file with the instructions specified in the file (OR use the default values). You can choose to use an existing VPC ID and Subnet IDs or create a new VPC and subnets by providing CIDR ranges in `base.tfvars` file
 
 ####  Step3: Update Terraform backend config file
 
-Update `~/aws-terraform-eks/live/preprod/eu-west-1/application/dev/backend.conf` with your local directory path. [state.tf](source/state.tf) file contains backend config. 
+Update `~/aws-eks-accelerator-for-terraform/live/preprod/eu-west-1/application/dev/backend.conf` with your local directory path. [state.tf](source/state.tf) file contains backend config.
 Local terraform state backend config variables
     
     path = "local_tf_state/ekscluster/preprod/application/dev/terraform-main.tfstate"
@@ -159,17 +161,17 @@ This role will become the Kubernetes  Admin by default.
 #### Step5: Run Terraform init 
 to initialize a working directory with configuration files
 
-    $ terraform init -backend-config ./live/preprod/eu-west-1/application/dev/backend.conf source
+    $ terraform init -backend-config ../live/preprod/eu-west-1/application/dev/backend.conf
     
 #### Step6: Run Terraform plan 
 to verify the resources created by this execution
 
-    $ terraform plan -var-file ./live/preprod/eu-west-1/application/dev/base.tfvars source
+    $ terraform plan -var-file ../live/preprod/eu-west-1/application/dev/base.tfvars
 
 #### Step7: Finally, Terraform apply 
 to create resources
 
-    $ terraform apply -var-file ./live/preprod/eu-west-1/application/dev/base.tfvars source
+    $ terraform apply -var-file ../live/preprod/eu-west-1/application/dev/base.tfvars
 
 ### Configure kubectl and test cluster
 EKS Cluster details can be extracted from terraform output or from AWS Console to get the name of cluster. This following command used to update the `kubeconfig` in your local machine where you run kubectl commands to interact with your EKS Cluster.

--- a/examples/eks-managed-nodegroups-fargate/eks-managed-nodegroups-fargate.tfvars
+++ b/examples/eks-managed-nodegroups-fargate/eks-managed-nodegroups-fargate.tfvars
@@ -9,7 +9,7 @@ tenant            = "aws001"    # AWS account name or unique id for tenant
 environment       = "preprod"   # Environment area eg., preprod or prod
 zone              = "dev"       # Environment with in one sub_tenant or business unit
 region            = "eu-west-1" # EKS Cluster region
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/examples/eks-with-bottlerocket-nodegroup/eks-with-bottlerocket-nodegroup.tfvars
+++ b/examples/eks-with-bottlerocket-nodegroup/eks-with-bottlerocket-nodegroup.tfvars
@@ -26,7 +26,7 @@ org               = "aws"     # Organization Name. Used to tag resources
 tenant            = "aws001"  # AWS account name or unique id for tenant
 environment       = "preprod" # Environment area eg., preprod or prod
 zone              = "dev"     # Environment with in one sub_tenant or business unit
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/examples/eks-with-lb-ingress/eks-with-lb-ingress.tfvars
+++ b/examples/eks-with-lb-ingress/eks-with-lb-ingress.tfvars
@@ -8,7 +8,7 @@ org               = "aws"     # Organization Name. Used to tag resources
 tenant            = "aws001"  # AWS account name or unique id for tenant
 environment       = "preprod" # Environment area eg., preprod or prod
 zone              = "dev"     # Environment with in one sub_tenant or business unit
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/examples/eks-with-traefik-ingress/traefik-ingress-with-eks.tfvars
+++ b/examples/eks-with-traefik-ingress/traefik-ingress-with-eks.tfvars
@@ -8,7 +8,7 @@ org               = "aws"     # Organization Name. Used to tag resources
 tenant            = "aws001"  # AWS account name or unique id for tenant
 environment       = "preprod" # Environment area eg., preprod or prod
 zone              = "dev"     # Environment with in one sub_tenant or business unit
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/examples/fluentbit-logging/eks-with-fluentbit-logging.tfvars
+++ b/examples/fluentbit-logging/eks-with-fluentbit-logging.tfvars
@@ -8,7 +8,7 @@ org               = "aws"     # Organization Name. Used to tag resources
 tenant            = "aws001"  # AWS account name or unique id for tenant
 environment       = "preprod" # Environment area eg., preprod or prod
 zone              = "dev"     # Environment with in one sub_tenant or business unit
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/live/preprod/eu-west-1/application/dev/base.tfvars
+++ b/live/preprod/eu-west-1/application/dev/base.tfvars
@@ -26,7 +26,7 @@ org               = "aws"     # Organization Name. Used to tag resources
 tenant            = "aws001"  # AWS account name or unique id for tenant
 environment       = "preprod" # Environment area eg., preprod or prod
 zone              = "dev"     # Environment with in one sub_tenant or business unit
-terraform_version = "Terraform v0.14.9"
+terraform_version = "Terraform v1.0.0"
 #---------------------------------------------------------#
 # VPC and PRIVATE SUBNET DETAILS for EKS Cluster
 #---------------------------------------------------------#

--- a/modules/launch-templates/main.tf
+++ b/modules/launch-templates/main.tf
@@ -55,7 +55,7 @@ resource "aws_launch_template" "default" {
 
   tag_specifications {
     resource_type = "instance"
-    tags          = merge(var.tags, map("Name", "${var.cluster_name}-${var.node_group_name}"))
+    tags          = merge(var.tags, tomap({"Name" = "${var.cluster_name}-${var.node_group_name}"}))
   }
 
   network_interfaces {

--- a/source/README.md
+++ b/source/README.md
@@ -2,8 +2,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.34.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.37.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.0.3 |
 
@@ -11,13 +11,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.37.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 14.0.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 15.2.0 |
 | <a name="module_eks-label"></a> [eks-label](#module\_eks-label) | ../modules/aws-resource-label |  |
 | <a name="module_helm"></a> [helm](#module\_helm) | ../helm |  |
 | <a name="module_iam"></a> [iam](#module\_iam) | ../modules/iam |  |
@@ -32,12 +32,12 @@
 
 | Name | Type |
 |------|------|
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/eks_cluster) | data source |
-| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/eks_cluster_auth) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/region) | data source |
-| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/3.34.0/docs/data-sources/security_group) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/eks_cluster_auth) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/region) | data source |
+| [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/3.37.0/docs/data-sources/security_group) | data source |
 
 ## Inputs
 

--- a/source/main.tf
+++ b/source/main.tf
@@ -16,9 +16,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 locals {
-  tags                = merge(map("kubernetes.io/cluster/${module.eks-label.id}", "shared"), map("created-by", var.terraform_version))
-  private_subnet_tags = merge(map("kubernetes.io/cluster/${module.eks-label.id}", "shared"), map("kubernetes.io/role/internal-elb", "1"), map("created-by", var.terraform_version))
-  public_subnet_tags  = merge(map("kubernetes.io/cluster/${module.eks-label.id}", "shared"), map("kubernetes.io/role/elb", "1"), map("created-by", var.terraform_version))
+  tags                = merge(tomap({"kubernetes.io/cluster/${module.eks-label.id}" = "shared"}), tomap({"created-by" = var.terraform_version}))
+  private_subnet_tags = merge(tomap({"kubernetes.io/cluster/${module.eks-label.id}" = "shared"}), tomap({"kubernetes.io/role/internal-elb" = "1"}), tomap({"created-by" = var.terraform_version}))
+  public_subnet_tags  = merge(tomap({"kubernetes.io/cluster/${module.eks-label.id}" = "shared"}), tomap({"kubernetes.io/role/elb" = "1"}), tomap({"created-by" = var.terraform_version}))
 }
 
 locals {
@@ -173,7 +173,7 @@ module "rbac" {
 # ---------------------------------------------------------------------------------------------------------------------
 module "eks" {
   source                          = "terraform-aws-modules/eks/aws"
-  version                         = "14.0.0"
+  version                         = "15.2.0"
   vpc_id                          = var.create_vpc == false ? var.vpc_id : module.vpc.vpc_id
   cluster_name                    = module.eks-label.id
   cluster_version                 = var.kubernetes_version

--- a/source/providers.tf
+++ b/source/providers.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.34.0"
+      version = "3.37.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/source/versions.tf
+++ b/source/versions.tf
@@ -17,5 +17,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Changes necessary to use this repo with Terraform v0.15.0 / v1.0.0:
* Updated Deployment Steps in README to use the source directory as the current working directory, as [required by TF v0.15.0+](https://www.terraform.io/docs/cli/commands/init.html#passing-a-different-configuration-directory). Also fixed the pre-requisites bullets.
* Use TF function [tomap()](https://www.terraform.io/docs/language/functions/map.html) instead of map(), which is deprecated and no longer available.
* Use TF function [tolist()](https://www.terraform.io/docs/language/functions/tolist.html) instead of list(), which is deprecated and no longer available. The list() function was used in the older version of the dependency module terraform-aws-modules/eks/aws, so to it was [necessary to upgrade the module version to 15.x](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1317). Upgrade of the eks module to v15.2.0 also [necessitated TF AWS provider version upgrade to 3.37.0](https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1340). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
